### PR TITLE
UI: Treat units as attoFIl, not wei

### DIFF
--- a/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
+++ b/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
@@ -16,7 +16,7 @@ import {
 
 import {Blockie} from 'rimble-ui';
 import {PieChart} from 'react-minimal-pie-chart';
-import {prettyPrintWei} from '../../utils/calculateWei';
+import {prettyPrintAttoFIL} from '../../utils/calculateWei';
 import {BigNumber} from 'ethers';
 import bigDecimal from 'js-big-decimal';
 
@@ -151,23 +151,23 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
                 labelPosition={112} // outer labels
                 data={[
                   {
-                    title: prettyPrintWei(myBalanceFree),
+                    title: prettyPrintAttoFIL(myBalanceFree),
                     value: myBalanceFreePercentage,
                     color: '#ea692b'
                   },
                   {
-                    title: prettyPrintWei(myBalanceLocked),
+                    title: prettyPrintAttoFIL(myBalanceLocked),
                     value: myBalanceLockedPercentage,
                     color: '#ea692b60'
                   },
 
                   {
-                    title: prettyPrintWei(hubBalanceLocked),
+                    title: prettyPrintAttoFIL(hubBalanceLocked),
                     value: hubBalanceLockedPercentage,
                     color: '#d5dbe360'
                   },
                   {
-                    title: prettyPrintWei(hubBalanceFree),
+                    title: prettyPrintAttoFIL(hubBalanceFree),
                     value: hubBalanceFreePercentage,
                     color: '#d5dbe3'
                   }
@@ -200,28 +200,28 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
             <LinearProgressWithLabel
               variant="determinate"
               value={hubBalanceFreePercentage}
-              label={prettyPrintWei(hubBalanceFree)}
+              label={prettyPrintAttoFIL(hubBalanceFree)}
               className={'bar hub'}
             />
             <span>Locked receive capacity </span>
             <LinearProgressWithLabel
               variant="determinate"
               value={hubBalanceLockedPercentage}
-              label={prettyPrintWei(hubBalanceLocked)}
+              label={prettyPrintAttoFIL(hubBalanceLocked)}
               className={'bar locked-hub'}
             />
             <span>Locked spend capacity </span>
             <LinearProgressWithLabel
               variant="determinate"
               value={myBalanceLockedPercentage}
-              label={prettyPrintWei(myBalanceLocked)}
+              label={prettyPrintAttoFIL(myBalanceLocked)}
               className={'bar locked-me'}
             />
             <span>Available spend capacity</span>
             <LinearProgressWithLabel
               variant="determinate"
               value={myBalanceFreePercentage}
-              label={prettyPrintWei(myBalanceFree)}
+              label={prettyPrintAttoFIL(myBalanceFree)}
               className={'bar me'}
             />
           </td>

--- a/packages/web3torrent/src/components/share-list/ShareList.test.tsx
+++ b/packages/web3torrent/src/components/share-list/ShareList.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {Router} from 'react-router-dom';
 import {RoutePath} from '../../routes';
 import {ShareList} from './ShareList';
-import {calculateWei, prettyPrintWei} from '../../utils/calculateWei';
+import {calculateWei, prettyPrintAttoFIL} from '../../utils/calculateWei';
 import prettier from 'prettier-bytes';
 import {preseededTorrentsUI} from '../../constants';
 
@@ -35,7 +35,7 @@ describe('<ShareList />', () => {
     expect(firstFileData.childAt(0).text()).toBe(preseededTorrentsUI[0].name);
     expect(firstFileData.childAt(1).text()).toBe(prettier(preseededTorrentsUI[0].length));
     expect(firstFileData.childAt(2).text()).toBe(
-      prettyPrintWei(calculateWei(preseededTorrentsUI[0].length))
+      prettyPrintAttoFIL(calculateWei(preseededTorrentsUI[0].length))
     );
     expect(firstFileData.childAt(5).find('button')).not.toBeNull();
   });

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {FormButton} from '../../form';
 import './ShareFile.scss';
-import {prettyPrintWei, calculateWei} from '../../../utils/calculateWei';
+import {calculateWei, prettyPrintAttoFIL} from '../../../utils/calculateWei';
 import prettier from 'prettier-bytes';
 import {useHistory} from 'react-router-dom';
 import {generateURL} from '../../../utils/url';
@@ -15,7 +15,7 @@ const ShareFile: React.FC<ShareFileProps> = ({file}: ShareFileProps) => {
     <tr className={'share-file'}>
       <td className="name-cell">{file.name}</td>
       <td className="other-cell">{prettier(file.length)}</td>
-      <td className="other-cell">{prettyPrintWei(calculateWei(file.length))}</td>
+      <td className="other-cell">{prettyPrintAttoFIL(calculateWei(file.length))}</td>
       <td className="button-cell">
         <FormButton name="download" onClick={() => history.push(generateURL(file))}>
           Download

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -6,7 +6,7 @@ import {DownloadLink} from './download-link/DownloadLink';
 import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
 import './TorrentInfo.scss';
 import {PeerNetworkStats} from './peer-network-stats/PeerNetworkStats';
-import {calculateWei, prettyPrintWei} from '../../utils/calculateWei';
+import {calculateWei, prettyPrintAttoFIL} from '../../utils/calculateWei';
 import {ChannelCache} from '../../clients/payment-channel-client';
 import {FaFileDownload, FaFileUpload} from 'react-icons/fa';
 import {ChannelsList} from './channels-list/ChannelsList';
@@ -64,7 +64,7 @@ const TorrentInfo: React.FC<TorrentInfoProps> = ({
             Size: {torrent.length === 0 ? '? Mb' : prettier(torrent.length)}
           </span>
           <span className="fileCost">
-            Cost: {torrent.length ? prettyPrintWei(calculateWei(torrent.length)) : 'unknown'}
+            Cost: {torrent.length ? prettyPrintAttoFIL(calculateWei(torrent.length)) : 'unknown'}
           </span>
           {torrent.status && (
             <span className="fileStatus">

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -3,7 +3,7 @@ import prettier from 'prettier-bytes';
 import React, {useContext} from 'react';
 import {ChannelCache, ChannelState} from '../../../clients/payment-channel-client';
 import './ChannelsList.scss';
-import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
+import {prettyPrintBytes, prettyPrintAttoFIL} from '../../../utils/calculateWei';
 import {BigNumber} from 'ethers';
 import {TorrentUI} from '../../../types';
 import {Blockie} from 'rimble-ui';
@@ -43,7 +43,7 @@ function channelIdToTableRow(
     dataTransferred = prettyPrintBytes(BigNumber.from(channelState.beneficiary.balance));
   }
 
-  const weiTransferred = prettyPrintWei(BigNumber.from(channelState.beneficiary.balance));
+  const attoFILTransferred = prettyPrintAttoFIL(BigNumber.from(channelState.beneficiary.balance));
 
   let connectionStatus;
   if (wire) {
@@ -103,7 +103,7 @@ function channelIdToTableRow(
       </td>
       <td className="exchanged">
         <div className="type">{isBeneficiary ? 'earned' : 'spent'}</div>
-        <div className="amount">{weiTransferred + ' '}</div>
+        <div className="amount">{attoFILTransferred + ' '}</div>
       </td>
     </tr>
   );

--- a/packages/web3torrent/src/utils/calculateWei.ts
+++ b/packages/web3torrent/src/utils/calculateWei.ts
@@ -36,3 +36,27 @@ export const prettyPrintWei = (wei: BigNumber): string => {
     return formattedString;
   }
 };
+
+// 1 wei is equivalent to 1 attoFil
+export const prettyPrintAttoFIL = (amount: BigNumber): string => {
+  const PRECISION = 1;
+  const names = ['attoFIL', 'femtoFIL', 'picoFIL', 'nanoFIL', 'microFIL', 'milliFIL', 'FIL'];
+  const decimals = [0, 3, 6, 9, 12, 15, 18];
+
+  if (!amount) {
+    return 'unknown';
+  } else if (amount.eq(BigNumber.from(0))) {
+    return '0 wei';
+  } else {
+    let formattedString;
+    decimals.forEach((decimal, index) => {
+      if (amount.gte(BigNumber.from(10).pow(decimal))) {
+        formattedString =
+          bigDecimal.divide(amount.toString(), BigNumber.from(10).pow(decimal), PRECISION) +
+          ' ' +
+          names[index];
+      }
+    });
+    return formattedString;
+  }
+};

--- a/packages/web3torrent/src/utils/prettyPrintWei.test.ts
+++ b/packages/web3torrent/src/utils/prettyPrintWei.test.ts
@@ -1,5 +1,5 @@
 import {BigNumber} from 'ethers';
-import {prettyPrintAttoFil, prettyPrintWei} from './calculateWei';
+import {prettyPrintAttoFIL, prettyPrintWei} from './calculateWei';
 
 describe('Pretty printing wei', () => {
   it.each`

--- a/packages/web3torrent/src/utils/prettyPrintWei.test.ts
+++ b/packages/web3torrent/src/utils/prettyPrintWei.test.ts
@@ -1,5 +1,5 @@
-import {bigNumberify} from 'ethers/utils';
-import {prettyPrintWei} from './calculateWei';
+import {BigNumber} from 'ethers';
+import {prettyPrintAttoFil, prettyPrintWei} from './calculateWei';
 
 describe('Pretty printing wei', () => {
   it.each`
@@ -12,6 +12,21 @@ describe('Pretty printing wei', () => {
     ${123456789}  | ${'123.5 Mwei'}
     ${1234567890} | ${'1.2 Gwei'}
   `('prettyPrintWei(bigNumberify($input)) = $output', ({input, output}) => {
-    expect(prettyPrintWei(bigNumberify(input))).toEqual(output);
+    expect(prettyPrintWei(BigNumber.from(input))).toEqual(output);
+  });
+});
+
+describe('Pretty printing attoFIL', () => {
+  it.each`
+    input         | output
+    ${18}         | ${'18.0 attoFIL'}
+    ${1001}       | ${'1.0 femtoFIL'}
+    ${1599}       | ${'1.6 femtoFIL'}
+    ${1234567}    | ${'1.2 picoFIL'}
+    ${12345678}   | ${'12.3 picoFIL'}
+    ${123456789}  | ${'123.5 picoFIL'}
+    ${1234567890} | ${'1.2 nanoFIL'}
+  `('prettyPrintAttoFIL(bigNumberify($input)) = $output', ({input, output}) => {
+    expect(prettyPrintAttoFIL(BigNumber.from(input))).toEqual(output);
   });
 });


### PR DESCRIPTION
<img width="587" alt="Screenshot 2023-02-28 at 09 51 22" src="https://user-images.githubusercontent.com/1833419/221817256-dbe4a26f-fd1d-4d72-807f-dc5107a119b4.png">


Open questions
1. Technically since hyperspace is a testnet, we are only using test FIL denoted tFIL. Should we use attoTFIL, nanoTFIL etc?
2. Should we think about a more maintainable way of swapping out the currency symbol depending on the chain (automatically, or based on an env var?)?