### PR TITLE
patch @statechannels/iframe-channel-provider

### DIFF
--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -22,6 +22,7 @@
     "@sentry/browser": "5.15.5",
     "@statechannels/channel-client": "0.3.0",
     "@statechannels/devtools": "0.1.4",
+    "@statechannels/iframe-channel-provider": "0.3.0-hyperspace-patch-0",
     "@svgr/webpack": "4.3.2",
     "@typescript-eslint/eslint-plugin": "2.18.0",
     "@typescript-eslint/parser": "2.18.0",
@@ -84,7 +85,6 @@
     "workbox-webpack-plugin": "5.0.0"
   },
   "devDependencies": {
-    "@statechannels/iframe-channel-provider": "0.3.0-hyperspace",
     "@storybook/addon-actions": "5.3.9",
     "@storybook/addon-knobs": "5.2.5",
     "@storybook/addon-notes": "5.2.5",


### PR DESCRIPTION
and move from dev to prod dependency

This brings in changes from https://github.com/statechannels/legacy-packages/pull/5