### PR TITLE
Ethereum to hyperspace (website text)

### DIFF
--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -193,7 +193,7 @@ const File: React.FC<Props> = props => {
             <p>
               <strong>How do I pay for the download?</strong>
               <br />
-              When you click "Start Download", you'll be asked to allocate an amount of ETH so
+              When you click "Start Download", you'll be asked to allocate an amount of tFIL so
               Web3Torrent can collect payments on your behalf and transfer those funds to peers who
               have pieces of the file . Unlike other systems, the payment is not upfront; instead,
               you pay as you download.

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -54,7 +54,7 @@ const Welcome: React.FC<Props> = () => {
           <a href="https://statechannels.org" target="_blank" rel="noopener noreferrer">
             State Channel
           </a>{' '}
-          technology to achieve seamless value transfer on the Hyperspace FVM test net. Peers can share
+          technology to achieve seamless value transfer on the Hyperspace FVM test net (connect your wallet <a href="https://chainlist.org/?search=hyperspace&testnets=true"><em>HERE</em></a>). Peers can share
           files in a torrent swarm and downloaders make micropayments to uploaders for the data they
           provide.
         </p>

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -54,7 +54,7 @@ const Welcome: React.FC<Props> = () => {
           <a href="https://statechannels.org" target="_blank" rel="noopener noreferrer">
             State Channels
           </a>{' '}
-          technology to achieve seamless value transfer on the ethereum blockchain. Peers can share
+          technology to achieve seamless value transfer on the Hyperspace FVM test net. Peers can share
           files in a torrent swarm and downloaders make micropayments to uploaders for the data they
           provide.
         </p>

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -52,7 +52,7 @@ const Welcome: React.FC<Props> = () => {
           </a>{' '}
           client, and uses{' '}
           <a href="https://statechannels.org" target="_blank" rel="noopener noreferrer">
-            State Channels
+            State Channel
           </a>{' '}
           technology to achieve seamless value transfer on the Hyperspace FVM test net. Peers can share
           files in a torrent swarm and downloaders make micropayments to uploaders for the data they


### PR DESCRIPTION
Replaces references to ethereum, eth, with references to Hyperspace, tFIL.
